### PR TITLE
S3_create_request_context_ex2

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -1279,6 +1279,8 @@ typedef S3Status (S3MultipartCommitResponseCallback)(const char *location,
  **/
 typedef S3Status (*S3SetupCurlCallback)(void *curlMulti, void *curlEasy,
                                         void *setupData);
+typedef S3Status (*S3SetupCurlCallbackEx)(void *curlMulti, void *curlEasy,
+                                          void *setupData, void *requestData);
 
 
 /** **************************************************************************
@@ -1667,6 +1669,10 @@ S3Status S3_create_request_context_ex(S3RequestContext **requestContextReturn,
                                       void *curlMulti,
                                       S3SetupCurlCallback setupCurlCallback,
                                       void *setupCurlCallbackData);
+S3Status S3_create_request_context_ex2(S3RequestContext **requestContextReturn,
+                                       void *curlMulti,
+                                       S3SetupCurlCallbackEx setupCurlCallback,
+                                       void *setupCurlCallbackData);
 
 
 /**

--- a/inc/request.h
+++ b/inc/request.h
@@ -111,6 +111,9 @@ typedef struct RequestParams
 
     // Request timeout. If 0, no timeout will be enforced
     int timeoutMs;
+
+    // Data passed to S3SetupCurlCallbackEx
+    void *curlCallbackData;
 } RequestParams;
 
 

--- a/inc/request_context.h
+++ b/inc/request_context.h
@@ -54,6 +54,7 @@ struct S3RequestContext
     struct Request *requests;
 
     S3SetupCurlCallback setupCurlCallback;
+    S3SetupCurlCallbackEx setupCurlCallbackEx;
     void *setupCurlCallbackData;
 };
 

--- a/src/bucket.c
+++ b/src/bucket.c
@@ -165,7 +165,8 @@ void S3_test_bucket(S3Protocol protocol, S3UriStyle uriStyle,
         &testBucketDataCallback,                      // fromS3Callback
         &testBucketCompleteCallback,                  // completeCallback
         tbData,                                       // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -320,7 +321,8 @@ void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
         createBucketFromS3Callback,                   // fromS3Callback
         &createBucketCompleteCallback,                // completeCallback
         cbData,                                       // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -408,7 +410,8 @@ void S3_delete_bucket(S3Protocol protocol, S3UriStyle uriStyle,
         0,                                            // fromS3Callback
         &deleteBucketCompleteCallback,                // completeCallback
         dbData,                                       // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -772,7 +775,8 @@ void S3_list_bucket(const S3BucketContext *bucketContext, const char *prefix,
         &listBucketDataCallback,                      // fromS3Callback
         &listBucketCompleteCallback,                  // completeCallback
         lbData,                                       // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request

--- a/src/bucket_metadata.c
+++ b/src/bucket_metadata.c
@@ -160,7 +160,8 @@ void S3_get_acl(const S3BucketContext *bucketContext, const char *key,
         &getAclDataCallback,                          // fromS3Callback
         &getAclCompleteCallback,                      // completeCallback
         gaData,                                       // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -366,7 +367,8 @@ void S3_set_acl(const S3BucketContext *bucketContext, const char *key,
         0,                                            // fromS3Callback
         &setXmlCompleteCallback,                      // completeCallback
         data,                                         // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -474,7 +476,8 @@ void S3_get_lifecycle(const S3BucketContext *bucketContext,
         &getLifecycleDataCallback,                    // fromS3Callback
         &getLifecycleCompleteCallback,                // completeCallback
         gaData,                                       // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -598,7 +601,8 @@ void S3_set_lifecycle(const S3BucketContext *bucketContext,
         0,                                            // fromS3Callback
         &setXmlCompleteCallback,                      // completeCallback
         data,                                         // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request

--- a/src/multipart.c
+++ b/src/multipart.c
@@ -149,7 +149,8 @@ void S3_initiate_multipart(S3BucketContext *bucketContext, const char *key,
         InitialMultipartCallback,                     // fromS3Callback
         InitialMultipartCompleteCallback,             // completeCallback
         mdata,                                        // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -191,7 +192,8 @@ void S3_abort_multipart_upload(S3BucketContext *bucketContext, const char *key,
         0,                                            // fromS3Callback
         AbortMultipartUploadCompleteCallback,         // completeCallback
         0,                                            // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        0                                             // curlCallbackData
     };
 
     // Perform the request
@@ -240,7 +242,8 @@ void S3_upload_part(S3BucketContext *bucketContext, const char *key,
         0,                                            // fromS3Callback
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     request_perform(&params, requestContext);
@@ -380,7 +383,8 @@ void S3_complete_multipart_upload(S3BucketContext *bucketContext,
         commitMultipartCallback,                      // fromS3Callback
         commitMultipartCompleteCallback,              // completeCallback
         data,                                         // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     request_perform(&params, requestContext);
@@ -975,7 +979,8 @@ void S3_list_multipart_uploads(S3BucketContext *bucketContext,
             &listMultipartDataCallback,              // fromS3Callback
             &listMultipartCompleteCallback,          // completeCallback
             lmData,                                  // callbackData
-            timeoutMs                                // timeoutMs
+            timeoutMs,                               // timeoutMs
+            callbackData                             // curlCallbackData
         };
 
         // Perform the request
@@ -1099,7 +1104,8 @@ void S3_list_parts(S3BucketContext *bucketContext, const char *key,
             &listPartsDataCallback,                  // fromS3Callback
             &listPartsCompleteCallback,              // completeCallback
             lpData,                                  // callbackData
-            timeoutMs                                // timeoutMs
+            timeoutMs,                               // timeoutMs
+            callbackData                             // curlCallbackData
         };
 
         // Perform the request

--- a/src/object.c
+++ b/src/object.c
@@ -72,7 +72,8 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
         0,                                            // fromS3Callback
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -267,7 +268,8 @@ void S3_copy_object_range(const S3BucketContext *bucketContext, const char *key,
         &copyObjectDataCallback,                      // fromS3Callback
         &copyObjectCompleteCallback,                  // completeCallback
         data,                                         // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -311,7 +313,8 @@ void S3_get_object(const S3BucketContext *bucketContext, const char *key,
         handler->getObjectDataCallback,               // fromS3Callback
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -353,7 +356,8 @@ void S3_head_object(const S3BucketContext *bucketContext, const char *key,
         0,                                            // fromS3Callback
         handler->completeCallback,                    // completeCallback
         callbackData,                                 // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -395,7 +399,8 @@ void S3_delete_object(const S3BucketContext *bucketContext, const char *key,
         0,                                            // fromS3Callback
         handler->completeCallback,                    // completeCallback
         callbackData,                                 // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request

--- a/src/request_context.c
+++ b/src/request_context.c
@@ -66,9 +66,23 @@ S3Status S3_create_request_context_ex(S3RequestContext **requestContextReturn,
     (*requestContextReturn)->verifyPeer = 0;
     (*requestContextReturn)->verifyPeerSet = 0;
     (*requestContextReturn)->setupCurlCallback = setupCurlCallback;
+    (*requestContextReturn)->setupCurlCallbackEx = NULL;
     (*requestContextReturn)->setupCurlCallbackData = setupCurlCallbackData;
 
     return S3StatusOK;
+}
+
+
+S3Status S3_create_request_context_ex2(S3RequestContext **requestContextReturn,
+                                       CURLM *curlm,
+                                       S3SetupCurlCallbackEx setupCurlCallback,
+                                       void *setupCurlCallbackData)
+{
+    S3Status retr = S3_create_request_context_ex(requestContextReturn, curlm, NULL, setupCurlCallbackData);
+    if (retr == S3StatusOK) {
+        (*requestContextReturn)->setupCurlCallbackEx = setupCurlCallback;
+    }
+    return retr;
 }
 
 

--- a/src/service.c
+++ b/src/service.c
@@ -192,7 +192,8 @@ void S3_list_service(S3Protocol protocol, const char *accessKeyId,
         &dataCallback,                                // fromS3Callback
         &completeCallback,                            // completeCallback
         data,                                         // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request

--- a/src/service_access_logging.c
+++ b/src/service_access_logging.c
@@ -353,7 +353,8 @@ void S3_get_server_access_logging(const S3BucketContext *bucketContext,
         &getBlsDataCallback,                          // fromS3Callback
         &getBlsCompleteCallback,                      // completeCallback
         gsData,                                       // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request
@@ -561,7 +562,8 @@ void S3_set_server_access_logging(const S3BucketContext *bucketContext,
         0,                                            // fromS3Callback
         &setSalCompleteCallback,                      // completeCallback
         data,                                         // callbackData
-        timeoutMs                                     // timeoutMs
+        timeoutMs,                                    // timeoutMs
+        callbackData                                  // curlCallbackData
     };
 
     // Perform the request


### PR DESCRIPTION
S3_create_request_context_ex allows an S3SetupCurlCallback to be associated with a newly-created S3RequestContext. Immediately after any request running against that S3RequestContext initializes a libcurl easy handle that function will be invoked and therefore be given an opportunity to perform some action (usually customizing the options associated with the easy handle). S3SetupCurlCallback is defined as:

```
typedef S3Status (*S3SetupCurlCallback)(void *curlMulti, void *curlEasy,
                                        void *setupData);
```

Where setupData is the setupCurlCallbackData supplied as the final argument to S3_create_request_context_ex.

While the ability to customize the options of any given easy handle is convenient and enables certain workflows an S3RequestContext is a multiplexer: It potentially handles many S3 requests and initializes easy handles for all of them. Because the only opaque pointer supplied to any S3SetupCurlCallback is the one supplied to
S3_create_request_context_ex this means that from within the S3SetupCurlCallback one can't tell which request against the S3RequestContext is intializing a certain easy handle in pursuit of and therefore it's difficult, impossible, or unwieldy to configure the easy handles differentially (for example one might want certain connections to have CURLOPT_VERIFYPEER and CURLOPT_VERIFYHOST disabled but not others).

To enable the above workflow added a new function: S3_create_request_context_ex2 which accepts an S3SetupCurlCallbackEx which is defined as:

```
typedef S3Status (*S3SetupCurlCallbackEx)(void *curlMulti, void *curlEasy,
                                          void *setupData, void *requestData);
```

Where requestData is the opaque pointer supplied when initiating the corresponding operation.