### PR TITLE
Allow UploadPart Response

### DIFF
--- a/src/multipart.cpp
+++ b/src/multipart.cpp
@@ -239,6 +239,9 @@ void S3_upload_part(const S3BucketContext *bucketContext, const char *key,
     char queryParams[512];
     snprintf(queryParams, 512, "partNumber=%d&uploadId=%s", seq, upload_id);
 
+    const auto fromS3Callback = [](const int, const char* const, void* const) {
+      return S3StatusOK;
+    };
     RequestParams params =
     {
         HttpRequestTypePUT,                           // httpRequestType
@@ -262,7 +265,7 @@ void S3_upload_part(const S3BucketContext *bucketContext, const char *key,
         handler->responseHandler.propertiesCallback,  // propertiesCallback
         handler->putObjectDataCallback,               // toS3Callback
         partContentLength,                            // toS3CallbackTotalSize
-        0,                                            // fromS3Callback
+        fromS3Callback,                               // fromS3Callback
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
         timeoutMs,                                    // timeoutMs


### PR DESCRIPTION
LocalStack version 2.2.0 emits a non-empty body (as opposed to an empty body as documented:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html) in response to UploadPart:

<?xml version='1.0' encoding='utf-8'?>
<UploadPartOutput />

Older LocalStack 2 versions likely suffer from the same issue. A bug report was filed with LocalStack after 2.2.0 which hopefully will result in this being solved for newer versions of LocalStack: https://github.com/localstack/localstack/issues/9032

Note that LocalStack 1.1.0 does not suffer from this issue.

Worked around the above by causing the operation initiated by S3_upload_part to ignore the response. Previously the absence of a fromS3Callback caused the operation to fail with S3StatusInternalError.