### PR TITLE
Allow PutObject Response

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -46,6 +46,9 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
                    const S3PutObjectHandler *handler, void *callbackData)
 {
     // Set up the RequestParams
+    const auto fromS3Callback = [](const int, const char* const, void* const) {
+      return S3StatusOK;
+    };
     RequestParams params =
     {
         HttpRequestTypePUT,                           // httpRequestType
@@ -68,8 +71,8 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
         putProperties,                                // putProperties
         handler->responseHandler.propertiesCallback,  // propertiesCallback
         handler->putObjectDataCallback,               // toS3Callback
-        contentLength,                                // toS3CallbackTotalSize
-        0,                                            // fromS3Callback
+        int64_t(contentLength),                       // toS3CallbackTotalSize
+        fromS3Callback,                               // fromS3Callback
         handler->responseHandler.completeCallback,    // completeCallback
         callbackData,                                 // callbackData
         timeoutMs,                                    // timeoutMs


### PR DESCRIPTION
Working around a similar LocalStack issue as
26add1898ac2c77d4c1d80676b16894fe0bb59b9 except as applied to PutObject. In this case the response returned by affected versions of LocalStack is:

<?xml version='1.0' encoding='utf-8'?>
<PutObjectOutput />