### PR TITLE
Request Payer

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -449,6 +449,13 @@ typedef enum
 } S3UriStyle;
 
 
+typedef enum
+{
+    S3RequestPayerOwner     = 0,
+    S3RequestPayerRequester = 1
+} S3RequestPayer;
+
+
 /**
  * S3GranteeType defines the type of Grantee used in an S3 ACL Grant.
  * Amazon Customer By Email - identifies the Grantee using their Amazon S3
@@ -743,6 +750,8 @@ typedef struct S3BucketContext
      * If NULL, the default region ("us-east-1") will be used.
      */
     const char *authRegion;
+
+    S3RequestPayer requestPayer;
 } S3BucketContext;
 
 

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -754,14 +754,7 @@ void S3_list_bucket(const S3BucketContext *bucketContext, const char *prefix,
     RequestParams params =
     {
         HttpRequestTypeGET,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         0,                                            // key
         queryParams[0] ? queryParams : 0,             // queryParams
         0,                                            // subResource

--- a/src/bucket_metadata.c
+++ b/src/bucket_metadata.c
@@ -137,14 +137,7 @@ void S3_get_acl(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypeGET,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         "acl",                                        // subResource
@@ -344,14 +337,7 @@ void S3_set_acl(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypePUT,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         "acl",                                        // subResource
@@ -453,14 +439,7 @@ void S3_get_lifecycle(const S3BucketContext *bucketContext,
     RequestParams params =
     {
         HttpRequestTypeGET,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         0,                                            // key
         0,                                            // queryParams
         "lifecycle",                                  // subResource
@@ -578,14 +557,7 @@ void S3_set_lifecycle(const S3BucketContext *bucketContext,
     RequestParams params =
     {
         HttpRequestTypePUT,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         0,                                            // key
         0,                                            // queryParams
         "lifecycle",                                  // subResource

--- a/src/multipart.cpp
+++ b/src/multipart.cpp
@@ -129,14 +129,7 @@ void S3_initiate_multipart(const S3BucketContext *bucketContext, const char *key
     RequestParams params =
     {
         HttpRequestTypePOST,                          // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         "uploads",                                    // subResource
@@ -190,14 +183,7 @@ void S3_abort_multipart_upload_ex(const S3BucketContext *bucketContext, const ch
     RequestParams params =
     {
         HttpRequestTypeDELETE,                        // httpRequestType
-        { bucketContext->hostName,                    // hostName
-     	  bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         subResource,                                  // subResource
@@ -245,14 +231,7 @@ void S3_upload_part(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypePUT,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         queryParams,                                  // queryParams
         0,                                            // subResource
@@ -386,14 +365,7 @@ void S3_complete_multipart_upload(const S3BucketContext *bucketContext,
     RequestParams params =
     {
         HttpRequestTypePOST,                          // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         queryParams,                                  // queryParams
         0,                                            // subResource
@@ -982,14 +954,7 @@ void S3_list_multipart_uploads(S3BucketContext *bucketContext,
         RequestParams params =
         {
             HttpRequestTypeGET,                      // httpRequestType
-            { bucketContext->hostName,               // hostName
-              bucketContext->bucketName,             // bucketName
-              bucketContext->protocol,               // protocol
-              bucketContext->uriStyle,               // uriStyle
-              bucketContext->accessKeyId,            // accessKeyId
-              bucketContext->secretAccessKey,        // secretAccessKey
-              bucketContext->securityToken,          // securityToken
-              bucketContext->authRegion },           // authRegion
+            *bucketContext,
             0,                                       // key
             queryParams[0] ? queryParams : 0,        // queryParams
             "uploads",                               // subResource
@@ -1107,14 +1072,7 @@ void S3_list_parts(S3BucketContext *bucketContext, const char *key,
         RequestParams params =
         {
             HttpRequestTypeGET,                      // httpRequestType
-            { bucketContext->hostName,               // hostName
-              bucketContext->bucketName,             // bucketName
-              bucketContext->protocol,               // protocol
-              bucketContext->uriStyle,               // uriStyle
-              bucketContext->accessKeyId,            // accessKeyId
-              bucketContext->secretAccessKey,        // secretAccessKey
-              bucketContext->securityToken,          // securityToken
-              bucketContext->authRegion },           // authRegion
+            *bucketContext,
             key,                                     // key
             queryParams[0] ? queryParams : 0,        // queryParams
             subResource,                             // subResource

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -52,14 +52,7 @@ void S3_put_object(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypePUT,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -247,15 +240,7 @@ void S3_copy_object_range(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypeCOPY,                          // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          destinationBucket ? destinationBucket :
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         destinationKey ? destinationKey : key,        // key
         qp,                                           // queryParams
         0,                                            // subResource
@@ -274,6 +259,9 @@ void S3_copy_object_range(const S3BucketContext *bucketContext, const char *key,
         timeoutMs,                                    // timeoutMs
         callbackData                                  // curlCallbackData
     };
+    if (destinationBucket) {
+        params.bucketContext.bucketName = destinationBucket;
+    }
 
     // Perform the request
     request_perform(&params, requestContext);
@@ -293,14 +281,7 @@ void S3_get_object(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypeGET,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -336,14 +317,7 @@ void S3_head_object(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypeHEAD,                          // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource
@@ -379,14 +353,7 @@ void S3_delete_object(const S3BucketContext *bucketContext, const char *key,
     RequestParams params =
     {
         HttpRequestTypeDELETE,                        // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         key,                                          // key
         0,                                            // queryParams
         0,                                            // subResource

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -438,6 +438,10 @@ static S3Status compose_amz_headers(const RequestParams *params,
                           params->bucketContext.securityToken);
     }
 
+    if (params->bucketContext.requestPayer == S3RequestPayerRequester) {
+        append_amz_header(values, 0, "x-amz-request-payer", "requester");
+    }
+
     if (!forceUnsignedPayload
         && (params->httpRequestType == HttpRequestTypeGET
             || params->httpRequestType == HttpRequestTypeCOPY

--- a/src/service_access_logging.c
+++ b/src/service_access_logging.c
@@ -330,14 +330,7 @@ void S3_get_server_access_logging(const S3BucketContext *bucketContext,
     RequestParams params =
     {
         HttpRequestTypeGET,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         0,                                            // key
         0,                                            // queryParams
         "logging",                                    // subResource
@@ -539,14 +532,7 @@ void S3_set_server_access_logging(const S3BucketContext *bucketContext,
     RequestParams params =
     {
         HttpRequestTypePUT,                           // httpRequestType
-        { bucketContext->hostName,                    // hostName
-          bucketContext->bucketName,                  // bucketName
-          bucketContext->protocol,                    // protocol
-          bucketContext->uriStyle,                    // uriStyle
-          bucketContext->accessKeyId,                 // accessKeyId
-          bucketContext->secretAccessKey,             // secretAccessKey
-          bucketContext->securityToken,               // securityToken
-          bucketContext->authRegion },                // authRegion
+        *bucketContext,
         0,                                            // key
         0,                                            // queryParams
         "logging",                                    // subResource


### PR DESCRIPTION
When accessing "Requester Pays" buckets a special header must be sent to verify that the requester acknowledges that they will be charged for the request:

  x-amz-request-payer: requester

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ObjectsinRequesterPaysBuckets.html

Previously this was not supported. Added the requestPayer member to S3BucketContext and corresponding integration to enable this workflow.