### PR TITLE
Skip Properties Callback on Failure

### DIFF
--- a/src/request.cpp
+++ b/src/request.cpp
@@ -204,7 +204,8 @@ static void request_headers_done(Request *request)
     // returning information about the error response itself
     if (request->propertiesCallback &&
         (request->httpResponseCode >= 200) &&
-        (request->httpResponseCode <= 299)) {
+        (request->httpResponseCode <= 299) &&
+        (request->status == S3StatusOK)) {
         request->status = (*(request->propertiesCallback))
             (&(request->responseHeadersHandler.responseProperties),
              request->callbackData);


### PR DESCRIPTION
When a request ends an attempt is made to dispatch the "properties callback" (which receives information provided by the HTTP headers). Previously this step was not skipped in a situation where:

- The HTTP headers had been received, and
- Receiving the request body had failed

This had the effect of overwriting the status of the overall request (a failure) with the status returned by the properties callback (possibly a success). This meant that requests which failed could be reported as having succeeded in the above-described scenario.