### PR TITLE
Remove S3StatusInternalError

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -267,7 +267,6 @@ typedef enum
      * Errors that prevent the S3 request from being issued or response from
      * being read
      **/
-    S3StatusInternalError                                   ,
     S3StatusOutOfMemory                                     ,
     S3StatusInterrupted                                     ,
     S3StatusInvalidBucketNameTooLong                        ,
@@ -315,6 +314,16 @@ typedef enum
     S3StatusConnectionFailed                                ,
     S3StatusAbortedByCallback                               ,
     S3StatusNotSupported                                    ,
+    S3StatusUnableToGetHttpResponseCode                     ,
+    S3StatusUnexpectedBody                                  ,
+    S3StatusCurlGlobalInitFailed                            ,
+    S3StatusCurlMultiAddHandleFailed                        ,
+    S3StatusUnexpectedCurlCode                              ,
+    S3StatusCurlMultiInfoDidNotReportDone                   ,
+    S3StatusCurlEasyGetInfoFailed                           ,
+    S3StatusCurlMultiRemoveHandleFailed                     ,
+    S3StatusCurlMultiPerformFailed                          ,
+    S3StatusXmlCreatePushParserCtxtFailed                   ,
 
     /**
      * Errors from the S3 service

--- a/src/general.c
+++ b/src/general.c
@@ -66,7 +66,6 @@ const char *S3_get_status_name(S3Status status)
             return #s
 
         handlecase(OK);
-        handlecase(InternalError);
         handlecase(OutOfMemory);
         handlecase(Interrupted);
         handlecase(InvalidBucketNameTooLong);
@@ -114,6 +113,16 @@ const char *S3_get_status_name(S3Status status)
         handlecase(ConnectionFailed);
         handlecase(AbortedByCallback);
         handlecase(NotSupported);
+        handlecase(UnableToGetHttpResponseCode);
+        handlecase(UnexpectedBody);
+        handlecase(CurlGlobalInitFailed);
+        handlecase(CurlMultiAddHandleFailed);
+        handlecase(UnexpectedCurlCode);
+        handlecase(CurlMultiInfoDidNotReportDone);
+        handlecase(CurlEasyGetInfoFailed);
+        handlecase(CurlMultiRemoveHandleFailed);
+        handlecase(CurlMultiPerformFailed);
+        handlecase(XmlCreatePushParserCtxtFailed);
         handlecase(ErrorAccessDenied);
         handlecase(ErrorAccountProblem);
         handlecase(ErrorAmbiguousGrantByEmailAddress);

--- a/src/request_context.cpp
+++ b/src/request_context.cpp
@@ -141,12 +141,12 @@ static S3Status process_request_context(S3RequestContext *requestContext, int *r
 
     while ((msg = curl_multi_info_read(requestContext->curlm, &junk))) {
         if (msg->msg != CURLMSG_DONE) {
-            return S3StatusInternalError;
+            return S3StatusCurlMultiInfoDidNotReportDone;
         }
         Request *request;
         if (curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIVATE,
                               (char **) (char *) &request) != CURLE_OK) {
-            return S3StatusInternalError;
+            return S3StatusCurlEasyGetInfoFailed;
         }
         // Remove the request from the list of requests
         if (request->prev == request->next) {
@@ -168,7 +168,7 @@ static S3Status process_request_context(S3RequestContext *requestContext, int *r
         }
         if (curl_multi_remove_handle(requestContext->curlm,
                                      msg->easy_handle) != CURLM_OK) {
-            return S3StatusInternalError;
+            return S3StatusCurlMultiRemoveHandleFailed;
         }
         // Finish the request, ensuring that all callbacks have been made,
         // and also releases the request
@@ -200,7 +200,7 @@ S3Status S3_runonce_request_context(S3RequestContext *requestContext,
         case CURLM_OUT_OF_MEMORY:
             return S3StatusOutOfMemory;
         default:
-            return S3StatusInternalError;
+            return S3StatusCurlMultiPerformFailed;
         }
 
         s3_status = process_request_context(requestContext, &retry);

--- a/src/simplexml.c
+++ b/src/simplexml.c
@@ -201,7 +201,7 @@ S3Status simplexml_add(SimpleXml *simpleXml, const char *data, int dataLen)
     if (!simpleXml->xmlParser &&
         (!(simpleXml->xmlParser = xmlCreatePushParserCtxt
            (&saxHandlerG, simpleXml, 0, 0, 0)))) {
-        return S3StatusInternalError;
+        return S3StatusXmlCreatePushParserCtxtFailed;
     }
 
     if (xmlParseChunk((xmlParserCtxtPtr) simpleXml->xmlParser, 


### PR DESCRIPTION
S3StatusInternalError was a catch all error for a wide variety of conditions which gave no insight into:

- What went wrong
- How to address or start debugging the problem

Removed the enumerator and replaced each use thereof with a use of a new error enumerator which exactly indicates the specific problem encountered.