### PR TITLE
S3_list_bucket: Pass Through All Errors From Callbacks

### DIFF
--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -655,7 +655,10 @@ static void listBucketCompleteCallback(S3Status requestStatus,
 
     // Make the callback if there is anything
     if (lbData->contentsCount || lbData->commonPrefixesCount) {
-        make_list_bucket_callback(lbData);
+        const S3Status status = make_list_bucket_callback(lbData);
+        if (status != S3StatusOK) {
+          requestStatus = status;
+        }
     }
 
     (*(lbData->responseCompleteCallback))


### PR DESCRIPTION
The operation initiated by S3_list_bucket parses up to:

- MAX_CONTENTS keys, or
- MAX_COMMON_PREFIXES common prefixes

Whichever comes first. Thereafter it emits a callback to the consumer of the operation and continues parsing.

Once the end of the operation is reached there may be a "tail" (i.e. some remaining keys or common prefixes). This tail is delivered to the consumer by the same callback mentioned above immediately before the operation reports completion (via a different callback).

Prior to this commit the S3Status returned by the latter of the above- described invocations was ignored. This meant that if the callback reported an error:

- Processing the tail the overall operation would complete with success (unless the operation was already completing with failure for a different reason)
- Processing any chunk but the tail the operation would immediately end with that error

Corrected this inconsistency by adopting the S3Status returned by the callback which processes the tail if it reports an error (this prevents success from this callback from overwriting a different error which is causing the operation to end).