### PR TITLE
S3StatusMax

### DIFF
--- a/inc/libs3.h
+++ b/inc/libs3.h
@@ -418,7 +418,8 @@ typedef enum
     S3StatusHttpErrorForbidden                              ,
     S3StatusHttpErrorNotFound                               ,
     S3StatusHttpErrorConflict                               ,
-    S3StatusHttpErrorUnknown
+    S3StatusHttpErrorUnknown                                ,
+    S3StatusMax = 2147483647
 } S3Status;
 
 


### PR DESCRIPTION
44eab4e3cbdba1a5c3800ec4d1a593ce2fe835ea improved the handling of unexpected libcurl errors by storing them in the high 16 bits of the resulting S3Status. Unfortunately S3Status didn't have an enumerator of sufficiently high value to ensure that storing and retrieving such unenumerated values was well-defined. This led to UBSan diagnostics of the form:

  /libs3/src/request.cpp:1673:18: runtime error: load of value 2293812,
  which is not a valid value for type 'S3Status'

Added S3StatusMax which a value of 2^32-1 which ensures that the enumerator has a sufficient number of bits to store libcurl errors without undefined behavior.